### PR TITLE
更正《反恐精英：全球攻势》条目名

### DIFF
--- a/data/topics-acgn.json
+++ b/data/topics-acgn.json
@@ -628,7 +628,7 @@
         },
         {
           "title": "反恐精英：全球攻势",
-          "displayTitle": "CS：GO",
+          "displayTitle": "CS:GO",
           "description": "《反恐精英：全球攻势》是Valve旗下的一个第一人称射击游戏。",
           "imageSrc": "https://img.moegirl.org.cn/common/thumb/3/3f/CSGO_730_logo.png/280px-CSGO_730_logo.png"
         }

--- a/data/topics-acgn.json
+++ b/data/topics-acgn.json
@@ -627,7 +627,7 @@
           "imageSrc": "https://img.moegirl.org.cn/common/thumb/a/a8/Wolong_cover.jpg/280px-Wolong_cover.jpg"
         },
         {
-          "title": "反恐精英:全球攻势",
+          "title": "反恐精英：全球攻势",
           "displayTitle": "CS：GO",
           "description": "《反恐精英：全球攻势》是Valve旗下的一个第一人称射击游戏。",
           "imageSrc": "https://img.moegirl.org.cn/common/thumb/3/3f/CSGO_730_logo.png/280px-CSGO_730_logo.png"


### PR DESCRIPTION
`反恐精英:全球攻势` -> `反恐精英：全球攻势`
`CS：GO` -> `CS:GO`（[官网](https://www.counter-strike.net/)所示）